### PR TITLE
add rule for no-unused-var

### DIFF
--- a/Labs/Lab 1 - PCF Quick Start.md
+++ b/Labs/Lab 1 - PCF Quick Start.md
@@ -645,6 +645,7 @@ Only perform this step if you are already comfortable with VSCode and writing Ty
          2,
          "smart"
        ],
+       "@typescript-eslint/no-unused-vars": "warn",
        "prettier/prettier": [
          "error",
          {


### PR DESCRIPTION
Amends default rule for typescript-eslint/no-unused-vars from Error to Warning